### PR TITLE
CH56x_uart.h: add missing include of CH56xSFR.h

### DIFF
--- a/drv/CH56x_uart.h
+++ b/drv/CH56x_uart.h
@@ -11,6 +11,8 @@
 #ifndef __CH56x_UART_H__
 #define __CH56x_UART_H__
 
+#include "CH56xSFR.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This is needed if user uses `UART0_RecvByte` macro for instance.